### PR TITLE
開発環境の整備

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,9 @@ gem "webpacker", "~> 5.0"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry-byebug'
-  gem 'pry-rails'
-  gem 'pry-doc'
+  gem "pry-byebug"
+  gem "pry-doc"
+  gem "pry-rails"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "webpacker", "~> 5.0"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-byebug'
+  gem 'pry-rails'
+  gem 'pry-doc'
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
@@ -102,6 +103,17 @@ GEM
     pluginator (1.5.0)
     pre-commit (0.39.0)
       pluginator (~> 1.5)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-doc (1.2.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -204,6 +216,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yard (0.9.26)
     zeitwerk (2.5.2)
 
 PLATFORMS
@@ -216,6 +229,9 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit
+  pry-byebug
+  pry-doc
+  pry-rails
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
@@ -232,4 +248,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.1.4
+   2.2.29


### PR DESCRIPTION
### 実装内容

- [x] 「開発環境・テスト環境のみ」にデバッグ用の gem を追加して，bundle install を実行

```
group :development, :test do
  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
  # 次の3つを追加
  gem 'pry-byebug'
  gem 'pry-rails'
  gem 'pry-doc'
end
```
##補足
以下は事前に導入済みです。

rails g controllerコマンドで生成されるファイルの設定

config/initializers/generators.rb
プルリクのテンプレートの設定

.github/pull_request_template.md
RuboCop の導入

.rubocop.yml