### PR TITLE
Feature/model table creation

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,2 @@
+class Text < ApplicationRecord
+end

--- a/db/migrate/20220209131941_create_texts.rb
+++ b/db/migrate/20220209131941_create_texts.rb
@@ -1,0 +1,11 @@
+class CreateTexts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :texts do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220209132024_create_movies.rb
+++ b/db/migrate/20220209132024_create_movies.rb
@@ -1,0 +1,11 @@
+class CreateMovies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :movies do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_02_09_132024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "movies", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "texts", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end


### PR DESCRIPTION
close #5

## 実装内容

- Textモデルとtextsテーブルを作成
  - カラムは「`genre`（`integer型`）」「`title`（`string型`）」「`content`（`text型`）」
  - 全て `NOT NULL` 制約を入れること
  - `genre` カラムのデフォルト値は `0` とすること

- Movieモデルとmoviesテーブルを作成
  - カラムは「`genre`（`integer型`）」「`title`（`string型`） 」と「`url`（`string型`）」
  - 全て `NOT NULL` 制約を入れること
  - `genre` カラムのデフォルト値は `0` とすること

※モデルのバリデーションは別タスク

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `rubocop -a` を実行

## スクリーンショット
動作確認結果
![動作確認](https://user-images.githubusercontent.com/86761987/153229479-65f49146-34b8-4a9b-b056-9c37a73b5521.PNG)

