### PR TITLE
navbarを設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,7 @@
 
 /* 全体 */
 
-@import "bootstrap/scss/bootstrap";
+@import 'bootstrap/scss/bootstrap';
 
 .base-container {
   margin: 0 auto;
@@ -28,4 +28,8 @@
 
 .mw-xl {
   max-width: 1200px;
+}
+
+body {
+  padding-top: 56px;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,8 +1,34 @@
-<% if user_signed_in? %>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-  <%= link_to "ログイン中のアドレス#{current_user.email}" %>
-<% else %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end%>  
+<nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top p-1">
+  <a class="navbar-brand" href="#">
+    <%= image_tag("yanbaru_expert_logo.png") %>
+  </a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto ml-3">
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> Ruby </a>
+        <div class="dropdown-menu" aria-labellendby="navbarDropdown">
+          <%= link_to "Ruby/Railsテキスト教材", "/texts", class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", "/movies", class: "dropdown-item" %>
+        </div>
+      </li>
+      <li class="nav-item active dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> PHP </a>
+        <div class="dropdown-menu" aria-labellendby="navbarDropdown">
+          <%= link_to "PHPテキスト教材", texts_path(genre: "php"), class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
+        </div>
+      </li>
+      <% if user_signed_in? %>
+        <li><%= link_to "アカウント編集", edit_user_registration_path, class: "nav-link active" %></li>
+        <li><%= link_to "ログアウト", destroy_user_session_path, class: "nav-link active",  method: :delete, data: { confirm: "ログアウトしますか？" } %></li>
+        <li><%= link_to "ログイン中のアドレス#{current_user.email}", class: "nav-link active" %></li>
+      <% else %>
+        <li><%= link_to "新規登録", new_user_registration_path, class: "nav-link active" %></li>
+        <li><%= link_to "ログイン", new_user_session_path, class: "nav-link active" %></li>
+      <% end%>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
close #12 

## 実装内容
- Bootstrap のナビバーを利用して作成
 - `app/views/layouts/_header.html.erb` を編集
 - .fixed-top を使用して上に固定
 - リンクは `link_to` ヘルパーメソッドを使用
 - PHPテキスト教材のパスは `texts_path(genre: "php")`, 動画教材は `movies_path(genre: "php")`を使用
 - md サイズ未満で「ハンバーガーメニュー」に切り替わるよう設定
 
## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行


