### PR TITLE
フラッシュメッセージを設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,3 +33,11 @@
 body {
   padding-top: 56px;
 }
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,6 +4,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "bootstrap/dist/js/bootstrap"
 
+
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
     <header>
       <%= render "layouts/header" %>
     </header>
+    <%= render "layouts/flash" %>
     <main>
+    
       <div class="base-container <%= max_width %>">
         <%= yield %>
       </div>


### PR DESCRIPTION
#  実装内容
- フラッシュの表示機能

  - ナビバー同様，横幅一杯とすること（mainタグの開始タグすぐ下）
  - 直接`application.html.erb`に書き込まず，部分テンプレート `app/views/layouts/_flash.html.erb` を作成して読み込むようにすること
 
- フラッシュの背景色を設定

  - Bootstrapに用意されているものを利用すること
  - `notice` は `alert-info` か `alert-success`, `alert` は `alert-danger` とすること 

#   参考文献

- <a href="https://www.yanbaru-code.com/texts/271">【やんばるエキスパート教材】メッセージ投稿アプリ その3）</a>

#  動作確認

- ログイン時・ログアウト時にフラッシュが表示されることを確認
【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
