### PR TITLE
Feature/railsvideo create

### DIFF
--- a/app/assets/stylesheets/movie.scss
+++ b/app/assets/stylesheets/movie.scss
@@ -1,0 +1,12 @@
+iframe {
+  width: 100%;
+  height: 100%;
+}
+
+.movie-header {
+  height: 190px;
+}
+
+.movie-body {
+  height: 190px;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,10 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true,
+    )
+  end
+end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -4,7 +4,7 @@ module MoviesHelper
       src: url,
       frameborder: 0,
       allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
-      allowfullscreen: true,
+      allowfullscreen: true
     )
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,5 @@
 class Movie < ApplicationRecord
+  RAILS_GENRE_LIST = %w[basic git ruby rails]
   with_options presence: true do
     validates :genre
     validates :title
@@ -11,6 +12,6 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,5 @@
 class Movie < ApplicationRecord
-  RAILS_GENRE_LIST = %w[basic git ruby rails]
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   with_options presence: true do
     validates :genre
     validates :title
@@ -12,6 +12,6 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,15 @@
+<div class="col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header movie-header p-0">
+      <%= embed_youtube(movie.url) %>
+    </div>
+    <div class="card-body text-dark movie-body">
+      <p>
+        <object>
+          <a class="btn btn-secondary btn-block">読破済みにする</a>
+        </object>
+      </p>
+      <p class="card-text mt-3">Lv.<%= "#{movie_counter}".to_i + 1%>：<%= movie.title %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <h1 class="text-center mt-2 mb-4">
+    Ruby/Rails 動画
+  </h1>
+  <div class="row">
+    <%= render partial: "movie", collection: @movies %>
+  </div>
+</div>


### PR DESCRIPTION
close #16 

## 実装内容
- Rails動画教材の一覧ページを作成
  - 表示するジャンルは `Movie::RAILS_GENRE_LIST` に制限
  - `each` を使わずコレクションをレンダリングを利用
  - 各動画にレベル表示
  - カードの下側部分に `height` を指定して揃える
  - 動画教材ページでしか利用しないスタイルは `app/assets/stylesheets/movies.scss` を作成して書き込む
  - 視聴済みボタンの配置


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行


