### PR TITLE
Feature/moviepage genre divide

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,10 @@
 class MoviesController < ApplicationController
+
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    if params[:genre]
+      @movies = @php = Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      @movies = @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,10 +1,9 @@
 class MoviesController < ApplicationController
-
   def index
-    if params[:genre]
-      @movies = @php = Movie.where(genre: Movie::PHP_GENRE_LIST)
-    else
-      @movies = @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
-    end
+    @movies = if params[:genre] == "php"
+                Movie.where(genre: Movie::PHP_GENRE_LIST)
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def page_title
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -5,6 +5,13 @@ class Movie < ApplicationRecord
     validates :title
     validates :url
   end
+  
+  PHP_GENRE_LIST = %w[php].freeze
+  with_options presence: true do
+    validates :genre
+    validates :title
+    validates :url
+  end
 
   enum genre: {
     invisible: 0, # 非表示

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -5,7 +5,7 @@ class Movie < ApplicationRecord
     validates :title
     validates :url
   end
-  
+
   PHP_GENRE_LIST = %w[php].freeze
   with_options presence: true do
     validates :genre

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h1 class="text-center mt-2 mb-4">
-    Ruby/Rails 動画
+    <%= page_title %>
   </h1>
   <div class="row">
     <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #19

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」が表示されるように修正
- 「PHP動画教材ページ」のタイトルは「PHP 動画」が表示されるように修正

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認
- 

## チェックリスト

- [ ] 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- [ ] 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- [ ] クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認