### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,10 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = if params[:genre] == "php"
+              Text.where(genre: Text::PHP_GENRE_LIST)
+            else
+              Text.where(genre: Text::RAILS_GENRE_LIST)
+            end
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,10 +1,10 @@
 class TextsController < ApplicationController
   def index
     @texts = if params[:genre] == "php"
-              Text.where(genre: Text::PHP_GENRE_LIST)
-            else
-              Text.where(genre: Text::RAILS_GENRE_LIST)
-            end
+               Text.where(genre: Text::PHP_GENRE_LIST)
+             else
+               Text.where(genre: Text::RAILS_GENRE_LIST)
+             end
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,12 @@ module ApplicationHelper
       "Ruby/Rails 動画"
     end
   end
+
+  def page_title_text
+    if params[:genre] == "php"
+      "PHPテキスト教材ページ"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
 
   def page_title_text
     if params[:genre] == "php"
-      "PHPテキスト教材ページ"
+      "PHPテキスト教材"
     else
       "Ruby/Rails テキスト教材"
     end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -5,6 +5,20 @@ class Text < ApplicationRecord
     validates :content
   end
 
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  with_options presence: true do
+    validates :genre
+    validates :title
+    validates :url
+  end
+
+  PHP_GENRE_LIST = %w[php].freeze
+  with_options presence: true do
+    validates :genre
+    validates :title
+    validates :url
+  end
+
   enum genre: {
     invisible: 0, # 非表示
     basic: 1,

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -6,18 +6,8 @@ class Text < ApplicationRecord
   end
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
-  with_options presence: true do
-    validates :genre
-    validates :title
-    validates :url
-  end
 
   PHP_GENRE_LIST = %w[php].freeze
-  with_options presence: true do
-    validates :genre
-    validates :title
-    validates :url
-  end
 
   enum genre: {
     invisible: 0, # 非表示

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="course_ttl">Ruby/Rails テキスト教材</h1>
+<h1 class="course_ttl"><%= page_title_text %></h1>
 <div class="row text_area">
 <%= render @texts %>
 </div>


### PR DESCRIPTION
close#14, #19

## 実装内容
- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
  - `PHPテキスト教材` のリンクをクリックした際のクエリパラメータ `?genre=php` を利用

- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする


##   動作確認

- 「Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認
- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- クエリパラメータ `?genre=php` を `php` 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認
## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
