### PR TITLE
動画教材のページネーションを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,3 +57,7 @@ Rails/FilePath:
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/markdown_helper.rb'
+
+#I18nLocaleTextsを無効化
+Rails/I18nLocaleTexts:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,6 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "enum_help"
+gem "kaminari"
 gem "redcarpet"
 gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ DEPENDENCIES
   devise-i18n
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,3 +52,7 @@ body {
   max-width: 376px;
   margin: 0 auto;
 }
+
+.pagination{
+  justify-content: center;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,9 +1,10 @@
 class MoviesController < ApplicationController
+  PER_PAGE = 12
   def index
     @movies = if params[:genre] == "php"
-                Movie.where(genre: Movie::PHP_GENRE_LIST)
+                Movie.where(genre: Movie::PHP_GENRE_LIST).page(params[:page]).per(PER_PAGE)
               else
-                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+                Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
               end
   end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -9,7 +9,7 @@
           <a class="btn btn-secondary btn-block">読破済みにする</a>
         </object>
       </p>
-      <p class="card-text mt-3">Lv.<%= "#{movie_counter}".to_i + 1%>：<%= movie.title %></p>
+      <p class="card-text mt-3">Lv.<%= @movies.offset_value + "#{movie_counter}".to_i + 1 %>：<%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -9,7 +9,7 @@
           <a class="btn btn-secondary btn-block">読破済みにする</a>
         </object>
       </p>
-      <p class="card-text mt-3">Lv.<%= @movies.offset_value + "#{movie_counter}".to_i + 1 %>：<%= movie.title %></p>
+      <p class="card-text mt-3">Lv.<%= @movies.offset_value + movie_counter + 1 %>：<%= movie.title %></p>
     </div>
   </div>
 </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,4 +5,5 @@
   <div class="row">
     <%= render partial: "movie", collection: @movies %>
   </div>
+  <%= paginate @movies %>
 </div>


### PR DESCRIPTION
close #22 

## 実装内容

- 「#16」完了後に行って下さい
- Gem `kaminari` をインストール
- 動画教材ページにページネーションを実装
  - 1ページの表示数は `12` 件とすること
- 2ページ目以降のレベル表示を連番にする
  - `offset_value` を利用
- ページネーションに `Bootstrap` を適用
```
rails g kaminari:views bootstrap4
```
- ページネーションを中央寄せにする

## 参考文献

[【やんばるエキスパート教材】検索機能(Ransack)](https://www.yanbaru-code.com/texts/221)


## 動作確認
- [x] Ruby/Rails動画 に ページネーション が付いていることを確認
- [x] 動画の1ページの最大表示数が 12 であることを確認
- [x] 2ページ目のレベル開始が 13 であることを確認
- [x] ページネーションに Bootstrap のスタイルが適用され，中央寄せになっていることを確認
